### PR TITLE
switch summary columns order & skip on img with more text

### DIFF
--- a/schedule/reports.go
+++ b/schedule/reports.go
@@ -49,9 +49,9 @@ func CreateChart(bot *tgbotapi.BotAPI) {
 		usersWorkouts, previousWeekWorkouts, leaders := collectUsersData(group)
 		userNames := group.GetUserFixedNamesList()
 		usersStringSlice := "'" + strings.Join(userNames, "', '") + "'"
-		workoutsStringSlice := strings.Join(usersWorkouts, ", ")
 		previousWorkoutsStringSlice := strings.Join(previousWeekWorkouts, ", ")
-		chartConfig := createChartConfig(usersStringSlice, workoutsStringSlice, previousWorkoutsStringSlice)
+		workoutsStringSlice := strings.Join(usersWorkouts, ", ")
+		chartConfig := createChartConfig(usersStringSlice, previousWorkoutsStringSlice, workoutsStringSlice)
 		qc := createQuickChart(chartConfig)
 		file, err := os.Create(fileName)
 		if err != nil {
@@ -110,23 +110,23 @@ func collectUsersData(group users.Group) (usersWorkouts, previousWeekWorkouts []
 	return
 }
 
-func createChartConfig(usersStringSlice, workoutsStringSlice, previousWorkoutsSlice string) string {
+func createChartConfig(usersStringSlice, previousWorkoutsSlice, workoutsStringSlice string) string {
 	chartConfig := fmt.Sprintf(`{
 		type: 'bar',
 		data: {
 			labels: [%s],
 			datasets: [
 				{
-					label: 'Workouts',
+					label: 'Last Week',
 					data: [%s]
 				},
 				{
-					label: 'Last Week',
+					label: 'Workouts',
 					data: [%s]
 				},
 			]
 		}
-	}`, usersStringSlice, workoutsStringSlice, previousWorkoutsSlice)
+	}`, usersStringSlice, previousWorkoutsSlice, workoutsStringSlice)
 	return chartConfig
 }
 

--- a/updates/handlers.go
+++ b/updates/handlers.go
@@ -59,8 +59,9 @@ func (update MediaUpdate) handle() error {
 	if update.Update.FromChat().IsPrivate() {
 		return nil
 	}
-	lines := strings.Split(strings.ToLower(update.Update.Message.Caption), "\n")
-	if len(lines) > 0 && strings.ReplaceAll(lines[0], " ", "") == "skip" {
+	caption := update.Update.Message.Caption
+	lines := strings.Split(strings.ToLower(caption), "\n")
+	if caption != "" && strings.ReplaceAll(lines[0], " ", "") == "skip" {
 		return nil
 	}
 	msg, err := handleWorkoutUpload(update)

--- a/updates/handlers.go
+++ b/updates/handlers.go
@@ -59,7 +59,8 @@ func (update MediaUpdate) handle() error {
 	if update.Update.FromChat().IsPrivate() {
 		return nil
 	}
-	if strings.ToLower(update.Update.Message.Caption) == "skip" {
+	lines := strings.Split(strings.ToLower(update.Update.Message.Caption), "\n")
+	if len(lines) > 0 && strings.ReplaceAll(lines[0], " ", "") == "skip" {
 		return nil
 	}
 	msg, err := handleWorkoutUpload(update)


### PR DESCRIPTION
- [x] switched columns sides in the weekly summary chart (previous week to the left of current week's workout)
- [x]  added the option to write skip on an image and add text after a line break.