### PR TITLE
fix: double memory allocation for Instagram image processing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,10 @@ services:
       - DBPATH=/app/fat.db
       - REDIS_ADDR=redis://redis:6379
       - PORT=8080
+      # Go memory limit (soft limit for GC, 450MB)
+      - GOMEMLIMIT=450MiB
+      # Reduce GC target percentage to be more aggressive (default is 100)
+      - GOGC=50
 
       # Core Service Tokens
       - TELEGRAM_APITOKEN=${TELEGRAM_APITOKEN}
@@ -35,6 +39,12 @@ services:
       - ./config.yaml:/app/config.yaml
       - ./fat.db:/app/fat.db
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+        reservations:
+          memory: 256M
 
   redis:
     image: redis:alpine

--- a/fly.toml
+++ b/fly.toml
@@ -10,6 +10,9 @@ primary_region = "lhr"
 DBPATH = "/data/fat.db"
 ENVIRONMENT = "production"
 WHOOP_REDIRECT_URI = "https://fatbot.fly.dev/whoop-callback"
+# Go memory settings for Instagram image processing
+GOMEMLIMIT = "450MiB"
+GOGC = "50"
 
 [mounts]
 source="fat_data"
@@ -22,3 +25,7 @@ destination="/data"
   auto_start_machines = true
   min_machines_running = 1
   processes = ["app"]
+
+[vm]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/spotlight/instagram.go
+++ b/spotlight/instagram.go
@@ -159,6 +159,9 @@ func CreateInstagramStoryFromPhoto(bot *tgbotapi.BotAPI, user users.User, photoF
 		return
 	}
 
+	// Force GC between renders to free memory from story canvas
+	runtime.GC()
+
 	postFile := fmt.Sprintf("post_%d_%d.jpg", user.TelegramUserID, ts)
 	log.Debug("Rendering high impact post image", "outFile", postFile)
 	if err := renderHighImpactImage(srcImg, 540, 540, user.GetName(), title, workoutCount, postFile); err != nil {


### PR DESCRIPTION
## Summary

- Increase Fly.io VM memory from default to 512MB
- Add GOMEMLIMIT=450MiB to control Go garbage collector
- Add GOGC=50 for more aggressive garbage collection
- Add extra runtime.GC() call between story and post rendering

## Notes

Bot crashes during Instagram image processing due to memory exhaustion when rendering multiple high-res images. These changes provide more headroom and better GC behavior.